### PR TITLE
add IPKG, reorganize modules

### DIFF
--- a/TParsec.ipkg
+++ b/TParsec.ipkg
@@ -1,0 +1,16 @@
+package TParsec
+
+sourcedir = src
+modules = TParsec
+        , TParsec.Chars
+        , TParsec.Combinators
+        , TParsec.Indexed
+        , TParsec.Induction
+        , TParsec.Inspect
+        , TParsec.NEList
+        , TParsec.Numbers
+        , TParsec.Running
+        , TParsec.SizedDict
+        , TParsec.Success
+
+opts = "-total"

--- a/src/Examples/Arithmetic.idr
+++ b/src/Examples/Arithmetic.idr
@@ -1,7 +1,7 @@
 module Examples.Arithmetic
 
 import TParsec
-import Running
+import TParsec.Running
 
 %default total
 

--- a/src/Examples/STLC.idr
+++ b/src/Examples/STLC.idr
@@ -1,8 +1,8 @@
 module Examples.STLC
 
 import TParsec
-import Running
-import NEList
+import TParsec.Running
+import TParsec.NEList
 
 %default total
 

--- a/src/TParsec.idr
+++ b/src/TParsec.idr
@@ -1,9 +1,9 @@
 module TParsec
 
-import public Indexed
-import public Induction
-import public Inspect
-import public Success
-import public Combinators
-import public Chars
-import public Numbers
+import public TParsec.Indexed
+import public TParsec.Induction
+import public TParsec.Inspect
+import public TParsec.Success
+import public TParsec.Combinators
+import public TParsec.Chars
+import public TParsec.Numbers

--- a/src/TParsec/Chars.idr
+++ b/src/TParsec/Chars.idr
@@ -1,11 +1,11 @@
-module Chars
+module TParsec.Chars
 
-import Indexed
-import Induction
-import Inspect
-import Combinators
-import NEList
-import Numbers
+import TParsec.Indexed
+import TParsec.Induction
+import TParsec.Inspect
+import TParsec.Combinators
+import TParsec.NEList
+import TParsec.Numbers
 
 %default total
 %access public export

--- a/src/TParsec/Combinators.idr
+++ b/src/TParsec/Combinators.idr
@@ -1,10 +1,10 @@
-module Combinators
+module TParsec.Combinators
 
-import Indexed
-import Induction as Box
-import Inspect
-import Success
-import NEList
+import TParsec.Indexed
+import TParsec.Induction as Box
+import TParsec.Inspect
+import TParsec.Success
+import TParsec.NEList
 
 %default total
 %access public export

--- a/src/TParsec/Indexed.idr
+++ b/src/TParsec/Indexed.idr
@@ -1,4 +1,4 @@
-module Indexed
+module TParsec.Indexed
 
 %default total
 %access public export

--- a/src/TParsec/Induction.idr
+++ b/src/TParsec/Induction.idr
@@ -1,6 +1,6 @@
-module Induction
+module TParsec.Induction
 
-import Indexed
+import TParsec.Indexed
 
 %access public export
 %default total

--- a/src/TParsec/Inspect.idr
+++ b/src/TParsec/Inspect.idr
@@ -1,7 +1,7 @@
-module Inspect
+module TParsec.Inspect
 
-import Indexed
-import SizedDict
+import TParsec.Indexed
+import TParsec.SizedDict
 
 %default total
 %access public export

--- a/src/TParsec/NEList.idr
+++ b/src/TParsec/NEList.idr
@@ -1,4 +1,4 @@
-module NEList
+module TParsec.NEList
 
 %default total
 %access public export

--- a/src/TParsec/Numbers.idr
+++ b/src/TParsec/Numbers.idr
@@ -1,9 +1,9 @@
-module Numbers
+module TParsec.Numbers
 
-import Indexed
-import Inspect
-import Combinators
-import NEList
+import TParsec.Indexed
+import TParsec.Inspect
+import TParsec.Combinators
+import TParsec.NEList
 
 %default total
 %access public export

--- a/src/TParsec/Running.idr
+++ b/src/TParsec/Running.idr
@@ -1,9 +1,9 @@
-module Running
+module TParsec.Running
 
-import Indexed
-import Success
-import Combinators
-import Inspect
+import TParsec.Indexed
+import TParsec.Success
+import TParsec.Combinators
+import TParsec.Inspect
 
 %default total
 %access public export

--- a/src/TParsec/SizedDict.idr
+++ b/src/TParsec/SizedDict.idr
@@ -1,4 +1,4 @@
-module SizedDict
+module TParsec.SizedDict
 
 %default total
 %access public export

--- a/src/TParsec/Success.idr
+++ b/src/TParsec/Success.idr
@@ -1,7 +1,7 @@
-module Success
+module TParsec.Success
 
-import Indexed
-import Inspect
+import TParsec.Indexed
+import TParsec.Inspect
 
 %default total
 %access public export


### PR DESCRIPTION
Closes #1 
I've also moved submodules under `TParsec`, so there's less chance of a name clash when using this as a lib.