### PR TITLE
Update to Idris 1.3: use lowercase patterns

### DIFF
--- a/src/TParsec/NEList.idr
+++ b/src/TParsec/NEList.idr
@@ -3,10 +3,10 @@ module TParsec.NEList
 %default total
 %access public export
 
-record NEList (A : Type) where
+record NEList (a : Type) where
   constructor MkNEList
-  head : A
-  tail : List A
+  head : a
+  tail : List a
 
 toList : NEList a -> List a
 toList xxs = head xxs :: tail xxs

--- a/src/TParsec/Success.idr
+++ b/src/TParsec/Success.idr
@@ -6,12 +6,12 @@ import TParsec.Inspect
 %default total
 %access public export
 
-record Success (Toks : Nat -> Type) (Tok : Type) (A : Type) (n : Nat) where
+record Success (toks : Nat -> Type) (tok : Type) (a : Type) (n : Nat) where
   constructor MkSuccess
-  Value     : A
+  Value     : a
   Size      : Nat
   Small     : LT Size n
-  Leftovers : Toks Size
+  Leftovers : toks Size
 
 map : (f : a -> b) -> All (Success toks tok a :-> Success toks tok b)
 map f (MkSuccess v s lt ts) = MkSuccess (f v) s lt ts


### PR DESCRIPTION
In 1.3 you can't use uppercase variables in patterns, which apparently record accessors desugar into.