### PR TITLE
use idris_opts instead of opts in elba.toml

### DIFF
--- a/elba.toml
+++ b/elba.toml
@@ -25,5 +25,5 @@ mods = ["Relation.Indexed"
        ,"TParsec.Running"
        ]
 
-opts = ["--total"]
+idris_opts = ["--total"]
 


### PR DESCRIPTION
it looks like that with the newest version of Elba (0.3.2) using `opts` produces an error 

    invalid manifest file: unknown field `opts`, expected one of `path`, `mods`, `idris_opts` for key `targets.lib`