### PR TITLE
expose Data.Tuple

### DIFF
--- a/TParsec.ipkg
+++ b/TParsec.ipkg
@@ -4,13 +4,14 @@ sourcedir = src
 modules = Relation.Indexed
         , Relation.Subset
         , Induction.Nat
-        
+
         , Data.Inspect
         , Data.DList
         , Data.NEList
         , Data.SizedDict
         , Data.These
         , Data.Trie
+        , Data.Tuple
 
         , TParsec
         , TParsec.Success


### PR DESCRIPTION
It looks like `Data.Tuple` was meant to be exposed to the API but wasn't in the IPKG, this PR fixes that.