### PR TITLE
Remove utility functions which are already defined in the new Prelude

### DIFF
--- a/src/Data/Tuple.idr
+++ b/src/Data/Tuple.idr
@@ -1,9 +1,5 @@
 module Data.Tuple
 
 public export
-mapFst : (a -> c) -> (a, b) -> (c, b)
-mapFst f (a, b) = (f a, b)
-
-public export
 mapSnd : (b -> c) -> (a, b) -> (a, c)
 mapSnd f (a, b) = (a, f b)

--- a/src/Util.idr
+++ b/src/Util.idr
@@ -8,19 +8,3 @@ public export
 head' : List a -> Maybe a
 head' []      = Nothing
 head' (x::xs) = Just x
-
-public export
-ignore : Functor f => f a -> f ()
-ignore = map (const ())
-
-public export
-Functor (Pair a) where
-  map f (x, y) = (x, f y)
-
-public export
-choice : (Foldable t, Alternative f) => t (f a) -> f a
-choice = foldr (<|>) empty
-
-public export
-choiceMap : (Foldable t, Alternative f) => (a -> f b) -> t a -> f b
-choiceMap f = foldr (\e, a => f e <|> a) empty


### PR DESCRIPTION
Duplicate definitions of new prelude functions resulted in ambiguous usage error.

Since the Prelude now contains a functor implementation for Pair, the `Data.Tuple.mapSnd` could also be removed in favour of using the functor `map`, but left it in since it may be preferred due to its more verbose name.

Note this branch does not compile even after these changes, due to some unrelated errors.