### PR TITLE
Fix uses of runStateT

### DIFF
--- a/src/Examples/Ambig.idr
+++ b/src/Examples/Ambig.idr
@@ -18,7 +18,7 @@ Parser' : Type -> Nat -> Type
 Parser' = Parser PosOr
                 (MkParameters Char
                               (\n => Vect n Char)
-                              (\c => MkPO $ ST $ \pos => Right ((), update c pos)))
+                              (\c => MkPO $ ST $ \pos => Right (update c pos, ())))
 
 Functor PosOr where
   map f (MkPO a) = MkPO $ map f a
@@ -49,7 +49,7 @@ Monad PosOr where
 
 parse' : String -> All (Parser' a) -> Either Position a
 parse' str p = let st = runParser p lteRefl $ sizedInput {toks= \n=>Vect n Char} $ tokenize {tok=Char} str in
-               map (Success.Value . fst) $ runStateT (runPO st) start
+               map (Success.Value . snd) $ runStateT start (runPO st)
 
 Amb : All (Parser' Unit)
 Amb = cmap () $ string "abracadabra" `alt` string "abraham"

--- a/src/TParsec/Running.idr
+++ b/src/TParsec/Running.idr
@@ -57,7 +57,7 @@ interface Pointed (a : Type) where
 
 public export
 (MonadRun m, Pointed s) => MonadRun (StateT s m) where
-  runMonad st = map fst $ runMonad $ runStateT st point
+  runMonad st = map snd $ runMonad $ runStateT point st
 
 public export
 MonadRun m => MonadRun (ResultT e m) where
@@ -65,7 +65,7 @@ MonadRun m => MonadRun (ResultT e m) where
 
 public export
 MonadRun m => MonadRun (TParsecT e a m) where
-  runMonad (MkTPT r) = map fst $ runMonad $ runStateT r (start, [])
+  runMonad (MkTPT r) = map snd $ runMonad $ runStateT (start, []) r
 
 public export
 parseMaybe : (MonadRun mn, Tokenizer (Tok p), SizedInput (Tok p) (Toks p)) =>
@@ -89,9 +89,9 @@ parseResults str par =
   let
     input  = sizedInput {tok = Tok p} {toks = Toks p} $ tokenize {tok = Tok p} str
     st = runParser par lteRefl input
-    res = sequence $ runMonad $ runResultT $ runStateT (runTPT st) (start, [])
+    res = sequence $ runMonad $ runResultT $ runStateT (start, []) (runTPT st)
    in
-  map (mapMaybe $ complete . Builtin.fst) res
+  map (mapMaybe $ complete . Builtin.snd) res
 
 public export
 parseResult : (MonadRun mn, Tokenizer (Tok p), SizedInput (Tok p) (Toks p)) =>

--- a/src/TParsec/Types.idr
+++ b/src/TParsec/Types.idr
@@ -77,8 +77,8 @@ public export
 (Monad m, Subset (Position, List a) e) => Alternative (TParsecT e a m) where
   empty = MkTPT $ ST $ MkRT . pure . SoftFail . into
   (MkTPT a) <|> (MkTPT b) = MkTPT $ ST $ \pos =>
-    MkRT $ (runResultT $ runStateT a pos) >>= (\r => case r of
-      SoftFail _ => runResultT $ runStateT b pos
+    MkRT $ (runResultT $ runStateT pos a) >>= (\r => case r of
+      SoftFail _ => runResultT $ runStateT pos b
       _ => pure r)
 
 public export
@@ -105,7 +105,7 @@ recordChar c = MkTPT $ ignore (modify (mapFst (update c)))
 public export
 commitT : Functor m => TParsecT e a m x -> TParsecT e a m x
 commitT (MkTPT m) = MkTPT $ ST $ \pos =>
-   MkRT $ map (result HardFail HardFail Value) (runResultT $ runStateT m pos)
+   MkRT $ map (result HardFail HardFail Value) (runResultT $ runStateT pos m)
 
 public export
 commit : Functor mn => All (Parser (TParsecT e an mn) p a :-> Parser (TParsecT e an mn) p a)


### PR DESCRIPTION
runStateT's signature was recently changed in Idris 2 ([5c76053c](https://github.com/idris-lang/Idris2/commit/5c76053cf304c7790477b5e5ef6c246878f102fb) and [19bad798](https://github.com/idris-lang/Idris2/commit/19bad79847153ca3968fdfa6cc34da9cd6d9596d)).
With this commit, TParsec builds again on my machine with Idris 2 master (`2e627ad16`).

However, two of the examples don't work:

`Parentheses.idr`

```Error: While processing right hand side of test. Can't solve constraint
--
  | between: Singleton () and maybe Delay Void Delay Singleton (parseMaybe "hel[{(lo({((wor))ld})wan)t}som{e()[n]o}i(s)e]?" (\{j:4116} =>
  | PAR')).
  |  
  | Examples/Parentheses.idr:45:8--45:22
  | \|
  | 45 \| test = MkSingleton ()
  | \|        ^^^^^^^^^^^^^^

```
On my machine, trying to compile `Examples/RegExp.idr` consumes all available memory and crashes.
The other examples compile for me.

I'm new to TParsec so please let me know if something can be simplified or if I screwed something up :)