### PR TITLE
Setting interface index multiplicity to 0

### DIFF
--- a/src/Data/Inspect.idr
+++ b/src/Data/Inspect.idr
@@ -11,7 +11,7 @@ View as a  Z    = Void
 View as a (S n) = (a, as n)
 
 public export
-interface Inspect (as : Nat -> Type) (a : Type) where
+interface Inspect (0 as : Nat -> Type) (0 a : Type) where
   inspect : All (as :-> Maybe :. View as a)
 
 public export

--- a/src/Relation/Subset.idr
+++ b/src/Relation/Subset.idr
@@ -5,7 +5,7 @@ import Util
 %default total
 
 public export
-interface Subset (a : Type) (b : Type) where
+interface Subset (0 a : Type) (0 b : Type) where
   into : a -> b
 
 public export

--- a/src/TParsec/Running.idr
+++ b/src/TParsec/Running.idr
@@ -20,7 +20,7 @@ data Singleton : a -> Type where
   MkSingleton : (v : a) -> Singleton v
 
 public export
-interface Tokenizer (tok : Type) where
+interface Tokenizer (0 tok : Type) where
   tokenize : String -> List tok
 
 public export
@@ -28,7 +28,7 @@ Tokenizer Char where
   tokenize = unpack
 
 public export
-interface SizedInput (tok : Type) (toks : Nat -> Type) where
+interface SizedInput (0 tok : Type) (0 toks : Nat -> Type) where
   sizedInput : (ts : List tok) -> toks (length ts)
 
 public export
@@ -36,7 +36,7 @@ SizedInput a (\n => Vect n a) where
   sizedInput = fromList
 
 public export
-interface MonadRun (mn : Type -> Type) where
+interface MonadRun (0 mn : Type -> Type) where
   runMonad : mn a -> List a
 
 public export
@@ -52,7 +52,7 @@ MonadRun Identity where
   runMonad (Id a) = pure a
 
 public export
-interface Pointed (a : Type) where
+interface Pointed (0 a : Type) where
   point : a
 
 public export


### PR DESCRIPTION
Otherwise new versions of idris2 complain with '{x} is not accessible in this context'