### PR TITLE
[ fix ] Unstick computation in tests. Ambig and STLCpos are working.

### DIFF
--- a/TParsec.ipkg
+++ b/TParsec.ipkg
@@ -11,13 +11,13 @@ modules = Util
         , Data.Inspect
         , Data.DList
         , Data.These
---        , Data.Trie
+        , Data.Trie
 
         , TParsec
         , TParsec.Success
         , TParsec.Result
         , TParsec.Position
---        , TParsec.Lexer
+        , TParsec.Lexer
         , TParsec.Types
         , TParsec.Combinators
         , TParsec.Combinators.Chars

--- a/src/Data/Trie.idr
+++ b/src/Data/Trie.idr
@@ -75,7 +75,7 @@ foldWithKeysM {a} {m} {c} fk fv = go []
   where
   go : List a -> Trie a b -> m c
   go as (MkTrie nd) =
-    bifold <$> bitraverse
+    bifold <$> These.bitraverse
                 (fv as)
                 (\sm => foldlM
                           (\x, (k, vs) => do let as' = as ++ [k]
@@ -83,5 +83,5 @@ foldWithKeysM {a} {m} {c} fk fv = go []
                                              z <- fk as'
                                              pure $ x <+> y <+> z)
                           neutral
-                          (toList sm))
+                          (SortedMap.toList sm))
                 nd

--- a/src/Examples/Ambig.idr
+++ b/src/Examples/Ambig.idr
@@ -1,10 +1,7 @@
 module Examples.Ambig
 
 import Data.List
-import Data.Vect
-import Data.Nat
-import Control.Monad.State
-import Data.NEList
+import Data.List1
 import TParsec
 import TParsec.Running
 

--- a/src/Examples/Arithmetic.idr
+++ b/src/Examples/Arithmetic.idr
@@ -15,6 +15,7 @@ module Examples.Arithmetic
 
 import TParsec
 import TParsec.Running
+import Data.List
 
 %default total
 

--- a/src/Examples/Lexing.idr
+++ b/src/Examples/Lexing.idr
@@ -2,6 +2,12 @@ module Examples.Lexing
 
 import TParsec.Lexer
 
+-- These imports unstick computation
+import Data.Trie
+import Data.Maybe
+import Data.These
+import Data.SortedMap
+
 %default total
 
 -- A small set of keywords for a language with expressions of the form

--- a/src/Examples/Parentheses.idr
+++ b/src/Examples/Parentheses.idr
@@ -2,6 +2,7 @@ module Examples.Parentheses
 
 import TParsec
 import TParsec.Running
+import Data.List
 
 -- Well-parenthesised string
 data PAR = LPAR | RPAR | LCUR | RCUR | LSQU | RSQU

--- a/src/Examples/STLC.idr
+++ b/src/Examples/STLC.idr
@@ -1,8 +1,8 @@
 module Examples.STLC
 
 import Data.List
+import Data.List1
 import Data.Vect
-import Data.NEList
 import TParsec
 import TParsec.Running
 

--- a/src/Examples/STLCpos.idr
+++ b/src/Examples/STLCpos.idr
@@ -2,7 +2,7 @@ module Examples.STLCpos
 
 import Control.Monad.State
 import Data.List
-import Data.NEList
+import Data.List1
 import TParsec
 import TParsec.Running
 
@@ -31,11 +31,11 @@ type =
     in
   chainr1 lt (box arr)
 
---Test : Type
---Test = (parseResult "'a -> ('b -> 'c) -> 'd" type = Value $ Just $ ARR (K "a") (ARR (ARR (K "b") (K "c")) (K "d")))
---
---test : Test
---test = Refl
+Test : Type
+Test = (parseResult "'a -> ('b -> 'c) -> 'd" type = (Value $ Just $ ARR (K "a") (ARR (ARR (K "b") (K "c")) (K "d"))))
+
+test : Test
+test = Refl
 
 mutual
   data Val : Type where
@@ -107,9 +107,8 @@ stlc = fix _ $ \rec =>
    in
   MkSTLC (val ihv ihn) (neu ihv ihn)
 
-{-
 Test2 : Type
-Test2 = parseResult "\\x.(\\y.y:'a->'a) x" (val stlc) = Value $ Just $
+Test2 = parseResult "\\x.(\\y.y:'a->'a) x" (val stlc) = (Value $ Just $
                                                         Lam (MkPosition 0 1) "x" $
                                                           Emb (MkPosition 0 3) $
                                                             App (MkPosition 0 17)
@@ -117,19 +116,19 @@ Test2 = parseResult "\\x.(\\y.y:'a->'a) x" (val stlc) = Value $ Just $
                                                                      (Lam (MkPosition 0 5) "y" $
                                                                        Emb (MkPosition 0 7) (Var "y"))
                                                                      (ARR (K "a") (K "a")))
-                                                                (Emb (MkPosition 0 17) (Var "x"))
+                                                                (Emb (MkPosition 0 17) (Var "x")))
 
 test2 : Test2
 test2 = Refl
 
 Test3 : Type
-Test3 = parseResult "\\x.1:'a->'a" (val stlc) = HardFail $ ParseError $ MkPosition 0 3
+Test3 = parseResult "\\x.1:'a->'a" (val stlc) = (HardFail $ ParseError $ MkPosition 0 3)
 
 test3 : Test3
 test3 = Refl
 
 Test4 : Type
-Test4 = parseResult "\\g.\\f.\\a.g a (f a)" (val stlc) = Value $ Just $
+Test4 = parseResult "\\g.\\f.\\a.g a (f a)" (val stlc) = (Value $ Just $
                                                          Lam (MkPosition 0 1) "g" $
                                                            Lam (MkPosition 0 4) "f" $
                                                              Lam (MkPosition 0 7) "a" $
@@ -140,13 +139,13 @@ Test4 = parseResult "\\g.\\f.\\a.g a (f a)" (val stlc) = Value $ Just $
                                                                           (Emb (MkPosition 0 11) (Var "a")))
                                                                      (Emb (MkPosition 0 14) $ App (MkPosition 0 16)
                                                                                                   (Var "f")
-                                                                                                  (Emb (MkPosition 0 16) (Var "a")))
+                                                                                                  (Emb (MkPosition 0 16) (Var "a"))))
 
 test4 : Test4
 test4 = Refl
 
 Test5 : Type
-Test5 = parseResult "\\g.\\f.\\a.(g a) (f a)" (val stlc) = Value $ Just $
+Test5 = parseResult "\\g.\\f.\\a.(g a) (f a)" (val stlc) = (Value $ Just $
                                                            Lam (MkPosition 0 1) "g" $
                                                              Lam (MkPosition 0 4) "f" $
                                                                Lam (MkPosition 0 7) "a" $
@@ -157,8 +156,7 @@ Test5 = parseResult "\\g.\\f.\\a.(g a) (f a)" (val stlc) = Value $ Just $
                                                                             (Emb (MkPosition 0 12) (Var "a")))
                                                                        (Emb (MkPosition 0 16) $ App (MkPosition 0 18)
                                                                                                     (Var "f")
-                                                                                                    (Emb (MkPosition 0 18) (Var "a")))
+                                                                                                    (Emb (MkPosition 0 18) (Var "a"))))
 
 test5 : Test5
 test5 = Refl
--}

--- a/src/TParsec/Lexer.idr
+++ b/src/TParsec/Lexer.idr
@@ -2,7 +2,6 @@ module TParsec.Lexer
 
 import Data.List
 import Data.Maybe
-import Data.Tuple
 import Data.Trie
 import public TParsec.Position
 


### PR DESCRIPTION
Needs `Data.List1.foldr1 and Data.List1.foldr1By to be public. (See: idris-lang/Idris2#3041)

With this PR all of the files are compiling. Some of the examples seem to take forever, but I've unblocked any stuck functions. The example files `Ambig.idr` and `STLCpos.idr` are completing with the tests uncommented. The latter takes about four seconds to run.

I'm not sure why `STLC.idr` has different behavior from `STLCpos.idr`.  (STLC doesn't finish with a test uncommented.)
